### PR TITLE
Changed cleanup to detect lack of xorg.conf backup

### DIFF
--- a/egpu-switcher
+++ b/egpu-switcher
@@ -412,14 +412,16 @@ function cleanup() {
 	rm -f ${xfile_internal}
 
 	# delete the xorg.conf file, if it is a symlink and restore the last backup
-	if [ -L ${xfile} ]; then
-		rm -f ${xfile}
-		local lastbackup=$(ls -t ${xfile_backup}.* | head -1)
-		if [ -e ${lastbackup} ]; then
-			print_info "Restoring latest backup ${green}${lastbackup}"
-			mv ${lastbackup} ${xfile}
-		fi
-	fi
+        if [ -L ${xfile} ]; then
+                rm -f ${xfile}
+                if [ -e ${xfile_backup}.* ]; then
+                        local lastbackup=$(ls -t ${xfile_backup}.* | head -1)
+                        print_info "Restoring latest backup ${green}${lastbackup}"
+                        mv ${lastbackup} ${xfile}
+                else
+                        print_info "Backup not found, restoring system without xorg.conf"
+                fi
+        fi
 
 	if [ ${hard} -eq 1 ]; then
 		print_info "Removing configuration files (--hard)"


### PR DESCRIPTION
While using this script, I noticed that the cleanup function did not properly clean files on the first try, forcing me to run it twice which worked. The error given was this:

<code># egpu-switcher cleanup --hard</code>
<code>[info] Starting cleanup process</code>
<code>ls: cannot access '/etc/X11/xorg.conf.backup.*': No such file or directory</code>
<code>[info] Restoring latest backup</code>
<code>mv: missing destination file operand after '/etc/X11/xorg.conf'</code>
<code>Try 'mv --help' for more information.</code>

The second try gave this:

<code># egpu-switcher cleanup --hard</code>
<code>[info] Starting cleanup process</code>
<code>[info] Removing configuration files (--hard)</code>
<code>/usr/bin/egpu-switcher: line 430: systemctl: command not found</code>

Note: I am not using systemd, I am using OpenRC on Gentoo hence the last line.
With this patch, I now get this on the first try:

<code># egpu-switcher cleanup --hard</code>
<code>[info] Starting cleanup process</code>
<code>[info] Backup not found, restoring system without xorg.conf</code>
<code>[info] Removing configuration files (--hard)</code>
<code>/usr/bin/egpu-switcher: line 432: systemctl: command not found</code>

I tested this with a pre-existing xorg.conf, it appears to work as normal:

<code># egpu-switcher cleanup --hard</code>
<code>[info] Starting cleanup process</code>
<code>[info] Restoring latest backup /etc/X11/xorg.conf.backup.20191227114249</code>
<code>[info] Removing configuration files (--hard)</code>
<code>/usr/bin/egpu-switcher: line 432: systemctl: command not found</code>